### PR TITLE
Condition rename: myapp/gargoyle.py shadows gargoyle package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Usage
 Gargoyle is typically used in two fashions. The first and simplest, is as a decorator. The decorator will automatically integrate with filters registered to the ``User`` model, as well as IP address::
 
 	from gargoyle.decorators import switch_is_active
-	
+
 	@switch_is_active('my switch name')
 	def my_view(request):
 	    return 'foo'
@@ -43,7 +43,7 @@ Gargoyle is typically used in two fashions. The first and simplest, is as a deco
 The second use is with the ``is_active`` method. This allows you to perform validation on your own custom objects::
 
 	from gargoyle import gargoyle
-	
+
 	def my_function(request):
 	    if gargoyle.is_active('my switch name', request):
 	        return 'foo'
@@ -52,7 +52,7 @@ The second use is with the ``is_active`` method. This allows you to perform vali
 
 	# with custom objects
 	from gargoyle import gargoyle
-	
+
 	def my_method(user):
 	    if gargoyle.is_active('my switch name', user):
 	        return 'foo'
@@ -62,15 +62,16 @@ The second use is with the ``is_active`` method. This allows you to perform vali
 Condition Sets
 ==============
 
-Gargoyle provides an easy way to hook in your own condition sets to allow additional filters. Simply place a ConditionSet class in ``myapp/gargoyle.py`` and it will automatically discover it::
+Gargoyle provides an easy way to hook in your own condition sets to allow additional filters. Simply place a ConditionSet class in ``myapp/gargoyle_conditions.py`` and it will automatically discover it::
 
+	from gargoyle import gargoyle
 	from gargoyle import conditions
 	from django.contrib.sites.models import Site
-	
+
 	class SiteConditionSet(conditions.ModelConditionSet):
 	    percent = conditions.Percent()
 	    domain = conditions.String()
-	
+
 	gargoyle.register(SiteConditionSet(Site))
 
 And now you can pass it into is_active::

--- a/gargoyle/__init__.py
+++ b/gargoyle/__init__.py
@@ -43,35 +43,35 @@ def autodiscover():
     from django.conf import settings
 
     for app in settings.INSTALLED_APPS:
-        # For each app, we need to look for an api.py inside that app's
-        # package. We can't use os.path here -- recall that modules may be
+        # For each app, we need to look for a gargoyle_conditions.py inside that
+        # app's package. We can't use os.path here -- recall that modules may be
         # imported different ways (think zip files) -- so we need to get
-        # the app's __path__ and look for admin.py on that path.
+        # the app's __path__ and look for gargoyle_conditions.py on that path.
 
         # Step 1: find out the app's __path__ Import errors here will (and
         # should) bubble up, but a missing __path__ (which is legal, but weird)
         # fails silently -- apps that do weird things with __path__ might
-        # need to roll their own admin registration.
+        # need to roll their own gargoyle condition registration.
         try:
             app_path = import_module(app).__path__
         except AttributeError:
             continue
 
-        # Step 2: use imp.find_module to find the app's admin.py. For some
-        # reason imp.find_module raises ImportError if the app can't be found
-        # but doesn't actually try to import the module. So skip this app if
-        # its admin.py doesn't exist
+        # Step 2: use imp.find_module to find the app's gargoyle_conditions.py.
+        # For some # reason imp.find_module raises ImportError if the app can't
+        # be found # but doesn't actually try to import the module. So skip this
+        # app if its gargoyle_conditions.py doesn't exist
         try:
-            imp.find_module('gargoyle', app_path)
+            imp.find_module('gargoyle_conditions', app_path)
         except ImportError:
             continue
 
-        # Step 3: import the app's admin file. If this has errors we want them
-        # to bubble up.
-        import_module("%s.gargoyle" % app)
+        # Step 3: import the app's gargoyle_conditions file. If this has errors
+        # we want them to bubble up.
+        import_module("%s.gargoyle_conditions" % app)
 
     # load builtins
     from gargoyle.builtins import *
-    
+
     # autodiscover was successful, reset loading flag.
     LOADING = False


### PR DESCRIPTION
With the current setup of using a myapp/gargoyle.py file for adding custom ConditionSet objects, I'm running in to an import problem. Since the file and the package are both named gargoyle, one of them shadows the other, and in this case, from myapp/gargoyle.py "import gargoyle" actually seems to be importing myapp.gargoyle. This obviously causes problems.

I'm not sure if this is something specific to the way I have my path configured. Either way, changing the file name from gargoyle.py to gargoyle_conditions.py eliminates the issue. 
