### PR TITLE
Added GARGOYLE_SWITCH_DEFAULTS setting, which allows engineers to set the

### DIFF
--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -60,3 +60,22 @@ If you prefer to use templatetags, Gargoyle provides a helper called ``ifswitch`
 	{% else %}
 	    switch_name is not active :(
 	{% endif %}
+
+Default Switch States
+~~~~~~~~~~~~~~~~~~~~~
+
+The GARGOYLE_SWITCH_DEFAULTS setting allows engineers to set the default state of a switch before it's been added via the gargoyle admin interface. In your settings.py add something like::
+
+    GARGOYLE_SWITCH_DEFAULTS = {
+        'new_switch': {
+          'is_active': True,
+          'label': 'New Switch',
+          'description': 'When you want the newness',
+        },
+        'funky_switch': {
+          'is_active': False,
+          'label': 'Funky Switch',
+          'description': 'Controls the funkiness.',
+        },
+    }
+

--- a/gargoyle/tests/tests.py
+++ b/gargoyle/tests/tests.py
@@ -14,7 +14,7 @@ class GargoyleTest(TestCase):
     
     def setUp(self):
         self.user = User.objects.create(username='foo', email='foo@example.com')
-        self.gargoyle = SwitchManager(Switch, key='key', value='value', instances=True)
+        self.gargoyle = SwitchManager(Switch, key='key', value='value', instances=True, auto_create=True)
         self.gargoyle.register(UserConditionSet(User))
         self.gargoyle.register(IPAddressConditionSet())
 
@@ -443,6 +443,28 @@ class GargoyleTest(TestCase):
         self.assertTrue(inner_condition[1], '192.168.1.1')
         self.assertTrue(inner_condition[2], '192.168.1.1')
         self.assertFalse(inner_condition[3])
+
+    def test_switch_defaults(self):
+        """Test that defaults pulled from GARGOYLE_SWITCH_DEFAULTS.
+
+        Requires SwitchManager to use auto_create.
+
+        """
+        self.assertTrue(self.gargoyle.is_active('active_by_default'))
+        self.assertFalse(self.gargoyle.is_active('inactive_by_default'))
+        self.assertEquals(
+            self.gargoyle['inactive_by_default'].label,
+            'Default Inactive',
+        )
+        self.assertEquals(
+            self.gargoyle['active_by_default'].label,
+            'Default Active',
+        )
+        active_by_default = self.gargoyle['active_by_default']
+        active_by_default.status = DISABLED
+        active_by_default.save()
+        self.assertFalse(self.gargoyle.is_active('active_by_default'))
+
 
 class GargoyleConstantTest(TestCase):
     def setUp(self):

--- a/runtests.py
+++ b/runtests.py
@@ -27,6 +27,18 @@ if not settings.configured:
         ROOT_URLCONF='',
         DEBUG=False,
         TEMPLATE_DEBUG=True,
+        GARGOYLE_SWITCH_DEFAULTS = {
+            'active_by_default': {
+              'is_active': True,
+              'label': 'Default Active',
+              'description': 'When you want the newness',
+            },
+            'inactive_by_default': {
+              'is_active': False,
+              'label': 'Default Inactive',
+              'description': 'Controls the funkiness.',
+            },
+        },
     )
     
 from django.test.simple import run_tests


### PR DESCRIPTION
Added GARGOYLE_SWITCH_DEFAULTS setting, which allows engineers to set the default state of a feature before it's been added via the gargoyle admin. Requires SwitchManager to use auto_create.

It works kind of like this:

GARGOYLE_SWITCH_DEFAULTS = {
    'active_by_default': {
      'is_active': True,
      'label': 'Default Active',
      'description': 'When you want the newness',
    },
    'inactive_by_default': {
      'is_active': False,
      'label': 'Default Inactive',
      'description': 'Controls the funkiness.',
    },
}
