### PR TITLE
Bug with SELECTIVE switch.

### DIFF
--- a/gargoyle/media/js/gargoyle.js
+++ b/gargoyle/media/js/gargoyle.js
@@ -100,7 +100,7 @@ $(document).ready(function () {
                 if (swtch.status == status) {
                     row.find(".toggled").removeClass("toggled");
                     el.addClass("toggled");
-                    if (!swtch.conditions && swtch.status == 2) {
+                    if ($.isArray(swtch.conditions) && swtch.conditions.length < 1 && swtch.status == 2) {
                         swtch.status = 3;
                     }
                     row.find('.status p').text(labels[swtch.status]);

--- a/gargoyle/models.py
+++ b/gargoyle/models.py
@@ -149,6 +149,12 @@ class Switch(models.Model):
 
         self.value[namespace][field_name] = [c for c in self.value[namespace][field_name] if c[1] != condition]
 
+        if not self.value[namespace][field_name]:
+            del self.value[namespace][field_name]
+
+            if not self.value[namespace]:
+                del self.value[namespace]
+
         if commit:
             self.save()
 


### PR DESCRIPTION
When a SELECTIVE switch is freshly created and has no conditions, it is treated as active. However, once conditions are added and then removed, leaving no conditions, instead of the value being {}, it might be stored as something like this: {"auth.user": {"is_superuser": [], "is_staff": []}}. This will then effectively be treated as a disabled switch, even though there are no conditions. This seems like a bug and is confusing, as these both look the same on the dashboard. To make it consistent removing conditions actually removes them from this JSON object too now.

Also, fixed an issue with the javascript where it wouldn't show the correct "(Active for everyone)" label in this scenario as empty object in JavaScript is truthy ie. !!{} === true
