### PR TITLE
Fix bug in ifswitch docs (endif -> endifswitch)

### DIFF
--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -59,7 +59,7 @@ If you prefer to use templatetags, Gargoyle provides a helper called ``ifswitch`
 	    switch_name is active!
 	{% else %}
 	    switch_name is not active :(
-	{% endif %}
+	{% endifswitch %}
 
 Default Switch States
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Using `endif` results in a TemplateSyntaxError during rendering (Invalid block tag: 'endif', expected 'endifswitch') since the tag is supposed to be closed by `endifswitch` (see https://github.com/disqus/gargoyle/blob/master/gargoyle/templatetags/gargoyle_tags.py#L22)
