### PR TITLE
Optional auto_create.

### DIFF
--- a/gargoyle/models.py
+++ b/gargoyle/models.py
@@ -361,4 +361,5 @@ class SwitchManager(ModelDict):
 
         return MockRequest(user, ip_address)
 
-gargoyle = SwitchManager(Switch, key='key', value='value', instances=True, auto_create=True)
+gargoyle = SwitchManager(Switch, key='key', value='value', instances=True,
+    auto_create=getattr(settings, 'GARGOYLE_AUTO_CREATE', True))


### PR DESCRIPTION
In our production environment we have experienced concurrency issues with auto_create=True: after code was deployed with a new feature switch, the first few requests that hit the site, all wanted to create the switch, but only one succeeded, and the others raised an IntegrityError.
