### PR TITLE
Added the ability to pass in custom objects to the ifswitch template tag.

### DIFF
--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -61,6 +61,12 @@ If you prefer to use templatetags, Gargoyle provides a helper called ``ifswitch`
 	    switch_name is not active :(
 	{% endifswitch %}
 
+``ifswitch`` can also be used with custom objects, like the ``gargoyle.is_active`` method::
+
+	{% ifswitch "my switch name" user %}
+	    "my switch name" is active!
+	{% endifswitch %}
+
 Default Switch States
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/gargoyle/templatetags/gargoyle_tags.py
+++ b/gargoyle/templatetags/gargoyle_tags.py
@@ -14,10 +14,13 @@ register = template.Library()
 
 @register.tag
 def ifswitch(parser, token):
-    try:
-        tag, name = token.contents.split(None, 1)
-    except ValueError:
+    bits = token.split_contents()
+    if len(bits) < 2:
         raise template.TemplateSyntaxError("%r tag requires an argument" % token.contents.split()[0])
+
+    tag = bits[0]
+    name = bits[1]
+    instances = bits[2:]
 
     nodelist_true = parser.parse(('else', 'endifswitch'))
     token = parser.next_token()
@@ -27,22 +30,22 @@ def ifswitch(parser, token):
         parser.delete_first_token()
     else:
         nodelist_false = template.NodeList()
-    
-    return SwitchNode(nodelist_true, nodelist_false, name)
+
+    return SwitchNode(nodelist_true, nodelist_false, name, instances)
 
 class SwitchNode(template.Node):
-    def __init__(self, nodelist_true, nodelist_false, name):
+    def __init__(self, nodelist_true, nodelist_false, name, instances):
         self.nodelist_true = nodelist_true
         self.nodelist_false = nodelist_false
         self.name = name
+        self.instances = [template.Variable(i) for i in instances]
 
     def render(self, context):
+        instances = [i.resolve(context) for i in self.instances]
         if 'request' in context:
-            conditions = [context['request']]
-        else:
-            conditions = []
+            instances.append(context['request'])
 
-        if not gargoyle.is_active(self.name, *conditions):
+        if not gargoyle.is_active(self.name, *instances):
             return self.nodelist_false.render(context)
 
         return self.nodelist_true.render(context)


### PR DESCRIPTION
We use a custom condition set to switch some functionality based on subdomain, and we had to make this modification in order to use the {% ifswitch %} template tag along with it.
