### PR TITLE
gargoyle X-CSRFToken conflicts with nexus

### DIFF
--- a/gargoyle/media/js/gargoyle.js
+++ b/gargoyle/media/js/gargoyle.js
@@ -1,30 +1,4 @@
 $(document).ready(function () {
-    /*
-    CSRF protection snippet copied from
-    http://docs.djangoproject.com/en/dev/ref/contrib/csrf/#ajax
-    */
-    $('html').ajaxSend(function(event, xhr, settings) {
-        function getCookie(name) {
-            var cookieValue = null;
-            if (document.cookie && document.cookie != '') {
-                var cookies = document.cookie.split(';');
-                for (var i = 0; i < cookies.length; i++) {
-                    var cookie = jQuery.trim(cookies[i]);
-                    // Does this cookie string begin with the name we want?
-                    if (cookie.substring(0, name.length + 1) == (name + '=')) {
-                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                        break;
-                    }
-                }
-            }
-            return cookieValue;
-        }
-        if (!(/^http:.*/.test(settings.url) || /^https:.*/.test(settings.url))) {
-            // Only send the token to relative URLs i.e. locally.
-            xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
-        }
-    });
-
     var api = function (url, params, succ) {
         $('#status').show();
         $.ajax({


### PR DESCRIPTION
The csrf header call here seems to duplicate the nexus call added here:

https://github.com/disqus/nexus/commit/ce8b32f0a1dfb20e8c9869379f889edd1b061217

When xhr.setRequestHeader is called multiple times, the browser sends a mangled token that looks like:

X-CSRFToken: [token], [token]

This fix simply removes the gargoyle token and allows nexus to take care of making sure the token exists.
