### PR TITLE
Added inheritance (backend) by using child:parent key naming scheme

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ except ImportError:
 tests_require = [
     'Django>=1.1',
     'South',
+    'nose',
+    'django-nose',
 ]
 
 setup(


### PR DESCRIPTION
This adds basic inheritance by using : separators for key names.

For example, if you had a key named:

`````` my_feature```

And a child named:

```my_feature:child```

You could disable the my_feature switch, which would force all children to be disabled.
``````
