### PR TITLE
add is_active stringfilter

### DIFF
--- a/gargoyle/templatetags/gargoyle_tags.py
+++ b/gargoyle/templatetags/gargoyle_tags.py
@@ -61,4 +61,4 @@ def is_active(request, switch):
       <my>html</my>
     {% endif %}
     """
-    return gargoyle.is_active(switch)
+    return gargoyle.is_active(switch, request)


### PR DESCRIPTION
With {% ifswitch %} is not possibile to add other conditions, this is a nice complement that can be used if you need to do something like:

```
    {% if request|is_active:"switchname" and not user.is_anonymous %}
      <my>html</my>
    {% else %}
       <my>other html</my>
    {% endif %}
```

In this way you don't write `<my>other html</my>` twice.
