### PR TITLE
Fix for issue #34

### DIFF
--- a/gargoyle/testutils.py
+++ b/gargoyle/testutils.py
@@ -35,7 +35,12 @@ class SwitchContextManager(object):
     def __init__(self, gargoyle=gargoyle, **keys):
         self.gargoyle = gargoyle
         self.is_active_func = gargoyle.is_active
-        self.keys = keys
+        switches = {}
+        if 'switches' in keys:
+            switches.update(keys['switches'])
+            del keys['switches']
+        switches.update(keys)
+        self.keys = switches
         self._state = {}
         self._values = {
             True: gargoyle.GLOBAL,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -857,6 +857,24 @@ class SwitchContextManagerTest(TestCase):
         self.assertFalse(test2())
         self.assertEquals(self.gargoyle['test'].status, GLOBAL)
 
+    def test_hierarchical(self):
+        switch = self.gargoyle['test:hierarchy']
+        switch.status = DISABLED
+
+        @switches(self.gargoyle, switches={'test:hierarchy':True})
+        def test():
+            return self.gargoyle.is_active('test:hierarchy')
+
+        self.assertTrue(test())
+        self.assertEquals(self.gargoyle['test:hierarchy'].status, DISABLED)
+        switch.status = GLOBAL
+
+        @switches(self.gargoyle, switches={'test:hierarchy': False})
+        def test2():
+            return self.gargoyle.is_active('test:hierarchy')
+
+        self.assertFalse(test2())
+
     def test_context_manager(self):
         switch = self.gargoyle['test']
         switch.status = DISABLED


### PR DESCRIPTION
Adds support for a "switches" kwarg on the decorator - if the switch name is
not a valid ID you can use @switches(switches={'test:a:hierarchy': True}) to set
the default value.

Also has basic test code.
