### PR TITLE
add SwitchActiveMixin to check for gargoyle switch

### DIFF
--- a/gargoyle/views.py
+++ b/gargoyle/views.py
@@ -1,0 +1,30 @@
+from django.core.exceptions import ImproperlyConfigured
+from django.core.urlresolvers import reverse
+from django.http import Http404
+from django.http import HttpResponseRedirect
+from django.views.generic.base import View
+
+from gargoyle import gargoyle
+
+
+class SwitchActiveMixin(View):
+    """
+    Verify that the switch given in gargoyle_switch is active, otherwise return 
+    a 404.
+    """
+    
+    gargoyle_switch = None
+    gargoyle_redirect_to = None
+    
+    def dispatch(self, request, *args, **kwargs):
+        if not self.gargoyle_switch:
+            raise ImproperlyConfigured(
+                    'SwitchActiveMixin requires gargoyle_switch setting')
+        if not gargoyle.is_active(self.gargoyle_switch, request):
+            if not self.gargoyle_redirect_to:
+                raise Http404('Switch \'%s\' is not active' % self.gargoyle_switch)
+            elif self.gargoyle_redirect_to.startswith('/'):
+                return HttpResponseRedirect(self.gargoyle_redirect_to)
+            else:
+                return HttpResponseRedirect(reverse(self.gargoyle_redirect_to))
+        return super(SwitchActiveMixin, self).dispatch(request, *args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except:
     pass
 
 tests_require = [
-    'Django>=1.2,<1.5',
+    'Django>=1.3,<1.5',
     'django-nose',
     'nose',
     'pyflakes',
@@ -29,7 +29,7 @@ dependency_links = [
 
 setup(
     name='gargoyle',
-    version='0.9.0',
+    version='0.9.0.dev.1',
     author='DISQUS',
     author_email='opensource@disqus.com',
     url='http://github.com/disqus/gargoyle',


### PR DESCRIPTION
Not sure about the django 1.3 requirement if they user chooses to ignore `gargoyle.views`.
