### PR TITLE
Add support for Django 1.4 timezone aware datetimes

### DIFF
--- a/gargoyle/models.py
+++ b/gargoyle/models.py
@@ -12,7 +12,8 @@ from django.utils.translation import ugettext_lazy as _
 try:
     from django.utils.timezone import now
 except ImportError:
-    from datetime.datetime import now
+    import datetime
+    now = datetime.datetime.now
 
 from jsonfield import JSONField
 


### PR DESCRIPTION
Try to import now from `django.utils.timezone` and fall back to the standard timezone naive now provided by `datetime.datetime`
