### PR TITLE
Don't re-use key variable when updating a switch through Nexus.

### DIFF
--- a/gargoyle/nexus_modules.py
+++ b/gargoyle/nexus_modules.py
@@ -174,10 +174,10 @@ class GargoyleModule(nexus.NexusModule):
         )
 
         changes = {}
-        for key, value in values.iteritems():
-            new_value = getattr(switch, key)
+        for attribute, value in values.iteritems():
+            new_value = getattr(switch, attribute)
             if new_value != value:
-                changes[key] = (value, new_value)
+                changes[attribute] = (value, new_value)
 
         if changes:
             if switch.key != key:


### PR DESCRIPTION
Fixes #60.
