### PR TITLE
DeprecationWarning with Django 1.5

### DIFF
--- a/gargoyle/nexus_modules.py
+++ b/gargoyle/nexus_modules.py
@@ -79,7 +79,10 @@ class GargoyleModule(nexus.NexusModule):
         return 'Gargoyle'
 
     def get_urls(self):
-        from django.conf.urls.defaults import patterns, url
+        try:
+            from django.conf.urls import patterns, url
+        except ImportError:  # Django<=1.4
+            from django.conf.urls.defaults import patterns, url
 
         urlpatterns = patterns('',
                                url(r'^add/$', self.as_view(self.add), name='add'),


### PR DESCRIPTION
I'm running Gargoyle with [the Django 1.5 release candidate](https://www.djangoproject.com/weblog/2013/jan/04/15-rc-1/). It logs a deprecation warning from `gargoyle.nexus_modules`. If I change warnings to errors and enable tracebacks, I see:

```
File "gargoyle/nexus_modules.py", line 82, in get_urls
  from django.conf.urls.defaults import patterns, url
File "django/conf/urls/defaults.py", line 3, in <module>
  DeprecationWarning)

DeprecationWarning: django.conf.urls.defaults is deprecated; use django.conf.urls instead
```
