### PR TITLE
Wrap id's of selectors in quotes

### DIFF
--- a/gargoyle/media/js/gargoyle.js
+++ b/gargoyle/media/js/gargoyle.js
@@ -129,7 +129,7 @@ $(document).ready(function () {
 
         $(this).
             parents("tr:first").
-            find("div[data-path=" + field[0] + "." + field[1] + "]").show();
+            find("div[data-path='" + field[0] + "." + field[1] + "']").show();
     });
 
     $("div.conditionsForm form").live("submit", function (ev) {
@@ -154,7 +154,7 @@ $(document).ready(function () {
 
         api(GARGOYLE.addCondition, data, function (swtch) {
             var result = $("#switchData").tmpl(swtch);
-            $("table.switches tr[data-switch-key="+ data.key + "]").replaceWith(result);
+            $("table.switches tr[data-switch-key='"+ data.key + "']").replaceWith(result);
         });
     });
 
@@ -172,7 +172,7 @@ $(document).ready(function () {
 
         api(GARGOYLE.delCondition, data, function (swtch) {
             var result = $("#switchData").tmpl(swtch);
-            $("table.switches tr[data-switch-key="+ data.key + "]").replaceWith(result);
+            $("table.switches tr[data-switch-key='"+ data.key + "']").replaceWith(result);
         });
 
     });
@@ -208,7 +208,7 @@ $(document).ready(function () {
 
                     $.facebox.close();
                 } else {
-                    $("table.switches tr[data-switch-key=" + curkey + "]").replaceWith(result);
+                    $("table.switches tr[data-switch-key='" + curkey + "']").replaceWith(result);
                     $.facebox.close();
                 }
                 result.click();


### PR DESCRIPTION
This fixes the cases with newer jQuery where selector contains dot characters.

Attempting to fix this issue: https://github.com/disqus/gargoyle/issues/72

jQuery version used by Nexus would still need to be updated to fix the issue completely.
