### PR TITLE
Support for custom User model for Django>=1.5

### DIFF
--- a/gargoyle/builtins.py
+++ b/gargoyle/builtins.py
@@ -11,11 +11,19 @@ from gargoyle.conditions import ModelConditionSet, RequestConditionSet, Percent,
     ConditionSet, OnOrAfterDate
 
 from django.conf import settings
-from django.contrib.auth.models import AnonymousUser, User
+from django.contrib.auth.models import AnonymousUser
 from django.core.validators import validate_ipv4_address
 
 import socket
 import struct
+
+
+try:
+    from django.contrib.auth import get_user_model
+except ImportError: # django < 1.5
+    from django.contrib.auth.models import User
+else:
+    User = get_user_model()
 
 
 class UserConditionSet(ModelConditionSet):


### PR DESCRIPTION
User conditions don't work in apps using Django 1.5's cusom AUTH_USER_MODEL . This pull requests uses get_user_model() instead of django.auth's User for Django>=1.5.
