### PR TITLE
Django 1.7 compatibility

### DIFF
--- a/gargoyle/conditions.py
+++ b/gargoyle/conditions.py
@@ -315,7 +315,11 @@ class ModelConditionSet(ConditionSet):
         return '%s.%s(%s)' % (self.__module__, self.__class__.__name__, self.get_namespace())
 
     def get_namespace(self):
-        return '%s.%s' % (self.model._meta.app_label, self.model._meta.module_name)
+        if hasattr(self.model._meta, 'model_name'):
+            model_name = self.model._meta.model_name
+        else:
+            model_name = self.model._meta.module_name
+        return '%s.%s' % (self.model._meta.app_label, model_name)
 
     def get_group_label(self):
         return self.model._meta.verbose_name.title()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ tests_require = [
 install_requires = [
     'django-modeldict>=1.2.0',
     'nexus>=0.2.3',
-    'django-jsonfield>=0.8.0,<0.9.4',
+    'django-jsonfield>=0.8.0,<0.9.14',
 ]
 
 


### PR DESCRIPTION
Add compatibility for Django 1.7 by checking for the presence of `Model._meta.model_name` to prevent deprecation warnings, and allowing newest version of `django-jsonfield` to be used.