### PR TITLE
import from django.template.base for 1.8

### DIFF
--- a/gargoyle/templatetags/gargoyle_helpers.py
+++ b/gargoyle/templatetags/gargoyle_helpers.py
@@ -6,9 +6,9 @@ gargoyle.templatetags.gargoyle_helpers
 :license: Apache License 2.0, see LICENSE for more details.
 """
 
-from django import template
+from django.template import base as template_base
 
-register = template.Library()
+register = template_base.Library()
 
 
 def raw(parser, token):
@@ -17,10 +17,10 @@ def raw(parser, token):
     text = []
     parse_until = 'endraw'
     tag_mapping = {
-        template.TOKEN_TEXT: ('', ''),
-        template.TOKEN_VAR: ('{{', '}}'),
-        template.TOKEN_BLOCK: ('{%', '%}'),
-        template.TOKEN_COMMENT: ('{#', '#}'),
+        template_base.TOKEN_TEXT: ('', ''),
+        template_base.TOKEN_VAR: ('{{', '}}'),
+        template_base.TOKEN_BLOCK: ('{%', '%}'),
+        template_base.TOKEN_COMMENT: ('{#', '#}'),
     }
     # By the time this template tag is called, the template system has already
     # lexed the template into tokens. Here, we loop over the tokens until
@@ -29,8 +29,8 @@ def raw(parser, token):
     # stripped off in a previous part of the template-parsing process.
     while parser.tokens:
         token = parser.next_token()
-        if token.token_type == template.TOKEN_BLOCK and token.contents == parse_until:
-            return template.TextNode(u''.join(text))
+        if token.token_type == template_base.TOKEN_BLOCK and token.contents == parse_until:
+            return template_base.TextNode(u''.join(text))
         start, end = tag_mapping[token.token_type]
         text.append(u'%s%s%s' % (start, token.contents, end))
     parser.unclosed_block_tag(parse_until)

--- a/gargoyle/templatetags/gargoyle_helpers.py
+++ b/gargoyle/templatetags/gargoyle_helpers.py
@@ -6,7 +6,10 @@ gargoyle.templatetags.gargoyle_helpers
 :license: Apache License 2.0, see LICENSE for more details.
 """
 
-from django.template import base as template_base
+try:
+    from django.template import base as template_base
+except ImportError:
+    from django import template as template_base
 
 register = template_base.Library()
 


### PR DESCRIPTION
In django 1.8, the `template` module has been moved to `django.template.base` from its original location directly under `django`.