### PR TITLE
throw exception when key longer than 64 characters

### DIFF
--- a/gargoyle/manager.py
+++ b/gargoyle/manager.py
@@ -40,6 +40,11 @@ class SwitchManager(ModelDict):
 
         >>> gargoyle.is_active('my_feature', request) #doctest: +SKIP
         """
+
+        # check for varchar(64)
+        if len(key) > 64:
+            raise ValueError('Gargoyle key can be max 64 chars, was: %s' % len(key))
+
         default = kwargs.pop('default', False)
 
         # Check all parents for a disabled state

--- a/gargoyle/testutils.py
+++ b/gargoyle/testutils.py
@@ -60,6 +60,11 @@ class SwitchContextManager(object):
             is_active_func = gargoyle.is_active
 
             def wrapped(key, *args, **kwargs):
+
+                # check for varchar(64)
+                if len(key) > 64:
+                    raise ValueError('Gargoyle key can be max 64 chars, was: %s' % len(key))
+
                 if key in self.keys:
                     return self.keys[key]
                 return is_active_func(key, *args, **kwargs)


### PR DESCRIPTION
I added a check on the length of gargoyle keys, this will prevent problems on SQL-databases with 'Strict SQL Mode' disabled.
